### PR TITLE
C++: Use refactored dataflow library in `cpp/command-line-injection`

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -71,8 +71,6 @@ edges
 | test.cpp:220:10:220:16 | strncat output argument | test.cpp:222:32:222:38 | command indirection |
 | test.cpp:220:19:220:26 | filename indirection | test.cpp:220:10:220:16 | strncat output argument |
 | test.cpp:220:19:220:26 | filename indirection | test.cpp:220:10:220:16 | strncat output argument |
-| test.cpp:220:19:220:26 | filename indirection | test.cpp:220:10:220:16 | strncat output argument |
-| test.cpp:220:19:220:26 | filename indirection | test.cpp:220:10:220:16 | strncat output argument |
 nodes
 | test.cpp:15:27:15:30 | argv | semmle.label | argv |
 | test.cpp:22:13:22:20 | sprintf output argument | semmle.label | sprintf output argument |
@@ -150,6 +148,7 @@ nodes
 | test.cpp:220:10:220:16 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:220:19:220:26 | filename indirection | semmle.label | filename indirection |
 | test.cpp:220:19:220:26 | filename indirection | semmle.label | filename indirection |
+| test.cpp:222:32:222:38 | command indirection | semmle.label | command indirection |
 | test.cpp:222:32:222:38 | command indirection | semmle.label | command indirection |
 subpaths
 | test.cpp:196:26:196:33 | filename | test.cpp:186:47:186:54 | filename | test.cpp:188:11:188:17 | command [post update] | test.cpp:196:10:196:16 | command [post update] |


### PR DESCRIPTION
Note: This merges into https://github.com/github/codeql/pull/12186!

This hopefully fixes the performance problems caused by the compatibility wrappers @aschackmull  🤞.

The changes to `.expected` is a bit surprising. I think I've translated it pretty much 1:1.

@aschackmull I ran the old version of the query on the new library and saw this join-on-state that might be worth looking into for you as well?
```
Tuple counts for DataFlowImpl#9021cc4c::Impl#DataFlowImpl2#f8ab311b::Config#::LocalFlowBigStep::additionalLocalFlowStepNodeCand2#4#ffff/4@d1c833j0 after 1m17s:
  1          ~0%     {3} r1 = SCAN num#DataFlowImpl2#f8ab311b::TMkConfigState#fff OUTPUT In.2 'state2', false, In.2 'state2'
  83818      ~3%     {3} r2 = JOIN r1 WITH DataFlowImpl#9021cc4c::Impl#DataFlowImpl2#f8ab311b::Config#::MkStage#Stage1#::Stage#Stage2Param#::revFlowAlias#3#fff_120#join_rhs ON FIRST 2 OUTPUT Lhs.0 'state1', Lhs.2 'state2', Rhs.2 'node2'
  7025457124 ~0%     {4} r3 = JOIN r2 WITH project#DataFlowImpl#9021cc4c::Impl#DataFlowImpl2#f8ab311b::Config#::MkStage#Stage1#::Stage#Stage2Param#::revFlow#5#fffff#2_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'node1', Lhs.2 'node2', Lhs.0 'state1', Lhs.1 'state2'
  22853      ~1%     {4} r4 = JOIN r3 WITH DataFlowImpl#9021cc4c::Impl#DataFlowImpl2#f8ab311b::Config#::additionalLocalStateStep#4#ffff#cpe#13 ON FIRST 2 OUTPUT Lhs.0 'node1', Lhs.2 'state1', Lhs.1 'node2', Lhs.3 'state2'
                     return r4
```

It's not present after rewriting the query, though:
```
Evaluated relational algebra for predicate DataFlowImpl#9021cc4c::Impl#TaintTracking#9bb50b40::Make#ExecTainted#91000ffb::ExecStateConfiguration#::C#::LocalFlowBigStep::additionalLocalFlowStepNodeCand2#4#ffff@335487i2 with tuple counts:
  83818  ~0%    {3} r1 = JOIN const_false WITH DataFlowImpl#9021cc4c::Impl#TaintTracking#9bb50b40::Make#ExecTainted#91000ffb::ExecStateConfiguration#::C#::MkStage#Stage1#::Stage#Stage2Param#::revFlowAlias#3#fff_201#join_rhs ON FIRST 1 OUTPUT Rhs.1, Rhs.2, Rhs.2
  62722  ~0%    {4} r2 = JOIN r1 WITH DataFlowImpl#9021cc4c::Impl#TaintTracking#9bb50b40::Make#ExecTainted#91000ffb::ExecStateConfiguration#::C#::additionalLocalFlowStepNodeCand1#2#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0, Lhs.2
  22852  ~1%    {4} r3 = JOIN r2 WITH project#DataFlowImpl#9021cc4c::Impl#TaintTracking#9bb50b40::Make#ExecTainted#91000ffb::ExecStateConfiguration#::C#::MkStage#Stage1#::Stage#Stage2Param#::revFlow#5#fffff#2 ON FIRST 2 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3
                return r3
```